### PR TITLE
Changed data type in LinkedList from string to a comparable data structure and fix go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module linkedList
+module github.com/pguo-480/Linked-List
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pguo-480/Linked-List
+module github.com/lyonusi/Linked-List
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/list/list.go
+++ b/list/list.go
@@ -2,8 +2,12 @@ package list
 
 import "fmt"
 
+type Data interface {
+	Compare(d Data) (bool, error)
+}
+
 type node struct {
-	data string
+	data Data
 	next *node
 }
 
@@ -14,18 +18,18 @@ type linkedList struct {
 }
 
 type LinkedList interface {
-	Add(data string)
-	Contains(data string) bool
-	IndexOf(data string) int
-	InsertAfter(index int, data string) error
-	Pop() (string, error)
-	Push(data string)
-	Remove(data string) error
+	Add(data Data)
+	Contains(data Data) bool
+	IndexOf(data Data) int
+	InsertAfter(index int, data Data) error
+	Pop() (Data, error)
+	Push(data Data)
+	Remove(data Data) error
 	RemoveByIndex(index int) error
-	Set(index int, data string) error
+	Set(index int, data Data) error
 	GetLength() int
-	GetHead() (string, error)
-	GetTail() (string, error)
+	GetHead() (Data, error)
+	GetTail() (Data, error)
 	Print()
 }
 
@@ -33,11 +37,11 @@ func NewLinkedList() LinkedList {
 	return &linkedList{}
 }
 
-func (l *linkedList) GetHead() (string, error) {
+func (l *linkedList) GetHead() (Data, error) {
 	fmt.Printf("...Getting head of the list...")
 	if l.length == 0 {
 		err := fmt.Errorf("[error: empty list]")
-		return "(null)", err
+		return nil, err
 	}
 	return l.head.data, nil
 }
@@ -46,11 +50,11 @@ func (l *linkedList) GetLength() (len int) {
 	return l.length
 }
 
-func (l *linkedList) GetTail() (string, error) {
+func (l *linkedList) GetTail() (Data, error) {
 	fmt.Printf("...Getting tail of the list...")
 	if l.length == 0 {
 		err := fmt.Errorf("[error: empty list]")
-		return "(null)", err
+		return nil, err
 	}
 	return l.tail.data, nil
 }
@@ -60,7 +64,7 @@ func (l *linkedList) Print() {
 	fmt.Printf("-------- START --------\n")
 	pointer := l.head
 	for pointer != nil {
-		fmt.Printf("%v -> ", pointer.data)
+		fmt.Printf("%+v -> ", pointer.data)
 		pointer = pointer.next
 	}
 	fmt.Printf("(null)\n")
@@ -69,16 +73,16 @@ func (l *linkedList) Print() {
 	if l.head == nil {
 		fmt.Println("Head is nil")
 	}
-	fmt.Println("Head =", l.head.data)
+	fmt.Printf("Head =%+v\n", l.head.data)
 
 	if l.tail == nil {
 		fmt.Println("Tail is nil")
 	}
-	fmt.Println("Tail =", l.tail.data)
+	fmt.Printf("Tail =%+v\n", l.tail.data)
 	fmt.Printf("--------- END ---------\n")
 }
 
-func (l *linkedList) Add(data string) {
+func (l *linkedList) Add(data Data) {
 	fmt.Printf("...Adding \"%v\" to the list...", data)
 	node := &node{
 		data: data,
@@ -94,11 +98,15 @@ func (l *linkedList) Add(data string) {
 	fmt.Println("[Success!]")
 }
 
-func (l *linkedList) Contains(data string) bool {
+func (l *linkedList) Contains(data Data) bool {
 	fmt.Printf("...Checking if the list contains \"%v\"...\n", data)
 	pointer := l.head
 	for i := 0; i < l.length; i++ {
-		if pointer.data == data {
+		equal, err := pointer.data.Compare(data)
+		if err != nil {
+			return false
+		}
+		if equal {
 			return true
 		} else {
 			pointer = pointer.next
@@ -107,11 +115,15 @@ func (l *linkedList) Contains(data string) bool {
 	return false
 }
 
-func (l *linkedList) IndexOf(data string) int {
+func (l *linkedList) IndexOf(data Data) int {
 	fmt.Printf("...Searching \"%v\" in the list...\n", data)
 	pointer := l.head
 	for i := 0; i < l.length; i++ {
-		if pointer.data == data {
+		equal, err := pointer.data.Compare(data)
+		if err != nil {
+			return -1
+		}
+		if equal {
 			return i
 		} else {
 			pointer = pointer.next
@@ -120,7 +132,7 @@ func (l *linkedList) IndexOf(data string) int {
 	return -1
 }
 
-func (l *linkedList) InsertAfter(index int, data string) error {
+func (l *linkedList) InsertAfter(index int, data Data) error {
 	fmt.Printf("...Inserting \"%v\" after node(%v) to the list...", data, index)
 	if l.length == 0 {
 		err := fmt.Errorf("[error: empty list]")
@@ -162,12 +174,12 @@ func (l *linkedList) InsertAfter(index int, data string) error {
 	return nil
 }
 
-func (l *linkedList) Pop() (string, error) {
+func (l *linkedList) Pop() (Data, error) {
 	fmt.Printf("...Poping the first node...")
 	if l.head == nil {
 		err := fmt.Errorf("[error: empty list]")
 		fmt.Println(err)
-		return "", err
+		return nil, err
 	}
 	data := l.head.data
 	fmt.Printf("\"%v\"...", data)
@@ -180,7 +192,7 @@ func (l *linkedList) Pop() (string, error) {
 	return data, nil
 }
 
-func (l *linkedList) Push(data string) {
+func (l *linkedList) Push(data Data) {
 	fmt.Printf("...Pushing \"%v\" to the list...", data)
 	node := &node{
 		data: data,
@@ -197,12 +209,16 @@ func (l *linkedList) Push(data string) {
 	fmt.Println("[Success!]")
 }
 
-func (l *linkedList) Remove(data string) error {
+func (l *linkedList) Remove(data Data) error {
 	fmt.Printf("...Removing \"%v\" from the list...", data)
 	pointer := l.head
 	var prevPointer *node
 	for i := 0; i < l.length; i++ {
-		if pointer.data == data {
+		equal, err := pointer.data.Compare(data)
+		if err != nil {
+			return nil
+		}
+		if equal {
 			if i == 0 {
 				l.head = l.head.next
 			} else if i == l.length-1 {
@@ -268,7 +284,7 @@ func (l *linkedList) RemoveByIndex(index int) error {
 	return nil
 }
 
-func (l *linkedList) Set(index int, data string) error {
+func (l *linkedList) Set(index int, data Data) error {
 	fmt.Printf("...Setting node(%v) as \"%v\"...", index, data)
 	if l.length == 0 {
 		err := fmt.Errorf("[error: empty list]")

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -2,17 +2,32 @@ package list
 
 // Basic imports
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
+
+type testData struct {
+	data string
+}
+
+func (t *testData) Compare(d Data) (bool, error) {
+	// Convert input d (a struct implementing list.Data interface) to TestData, "ok" will be false if fields of d not match with fields in TestData
+	compareData, ok := d.(*testData)
+	if !ok {
+		return false, fmt.Errorf("Input cannot be converted to TestData")
+	} else {
+		return t.data == compareData.data, nil
+	}
+}
 
 // Define the suite, and absorb the built-in basic suite
 // functionality from testify - including a T() method which
 // returns the current testing context
 type ListTestSuite struct {
 	suite.Suite
-	singleNodeValue   string
+	singleNodeValue   Data
 	emptyList         *linkedList
 	listWithOneItem   *linkedList
 	listWithTwoItems  *linkedList
@@ -22,7 +37,7 @@ type ListTestSuite struct {
 // before each test
 func (s *ListTestSuite) SetupTest() {
 
-	s.singleNodeValue = "single"
+	s.singleNodeValue = &testData{"single"}
 	s.emptyList = &linkedList{}
 
 	singleNode := &node{
@@ -38,7 +53,7 @@ func (s *ListTestSuite) SetupTest() {
 	s.listWithTwoItems = &linkedList{
 		length: 2,
 		head: &node{
-			data: "1",
+			data: &testData{"1"},
 			next: singleNode,
 		},
 		tail: singleNode,
@@ -47,11 +62,11 @@ func (s *ListTestSuite) SetupTest() {
 	s.listWithManyItems = &linkedList{
 		length: 4,
 		head: &node{
-			data: "1",
+			data: &testData{"1"},
 			next: &node{
-				data: "2",
+				data: &testData{"2"},
 				next: &node{
-					data: "3",
+					data: &testData{"3"},
 					next: singleNode,
 				},
 			}},
@@ -68,7 +83,7 @@ func TestListListTestSuite(t *testing.T) {
 // All methods that begin with "Test" are run as tests within a
 // suite.
 func (s *ListTestSuite) TestAddShouldAddNodeToHeadIfListIsEmpty() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.emptyList.Add(nodeValue)
 	s.Assert().Equal(nodeValue, s.emptyList.head.data)
 	s.Assert().Nil(s.emptyList.head.next)
@@ -80,7 +95,7 @@ func (s *ListTestSuite) TestAddShouldAddNodeToHeadIfListIsEmpty() {
 }
 
 func (s *ListTestSuite) TestAddShouldAddNodeToTailIfListHasOneNode() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.listWithOneItem.Add(nodeValue)
 	s.Assert().Equal(s.singleNodeValue, s.listWithOneItem.head.data)
 
@@ -92,11 +107,11 @@ func (s *ListTestSuite) TestAddShouldAddNodeToTailIfListHasOneNode() {
 }
 
 func (s *ListTestSuite) TestAddShouldAddNodeToTailIfListHasManyNode() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.listWithManyItems.Add(nodeValue)
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.head.next.next.next.data)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.head.next.next.next.next.data)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.tail.data)
@@ -106,21 +121,21 @@ func (s *ListTestSuite) TestAddShouldAddNodeToTailIfListHasManyNode() {
 
 func (s *ListTestSuite) TestInsertAfterShouldReturnErrorIfListIsEmpty() {
 	index := 0
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.Assert().EqualError(s.emptyList.InsertAfter(index, nodeValue), "[error: empty list]")
 }
 func (s *ListTestSuite) TestInsertAfterShouldReturnErrorIfIndexExceededLength() {
 	index := 5
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.Assert().EqualError(s.listWithTwoItems.InsertAfter(index, nodeValue), "[invalid index: exceeded maximum index (1)]")
 }
 func (s *ListTestSuite) TestInsertAfterShouldReturnErrorIfIndexIsNegative() {
 	index := -10
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 	s.Assert().EqualError(s.listWithTwoItems.InsertAfter(index, nodeValue), "[invalid index: should be [0 - 1]]")
 }
 func (s *ListTestSuite) TestInsertAfterShouldAddNodeAtTailIfIndexEqualsLength() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 
 	index := 0
 	s.listWithOneItem.InsertAfter(index, nodeValue)
@@ -137,9 +152,9 @@ func (s *ListTestSuite) TestInsertAfterShouldAddNodeAtTailIfIndexEqualsLength() 
 	s.listWithManyItems.InsertAfter(index, nodeValue)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.tail.data)
 
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.head.next.next.next.data)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.head.next.next.next.next.data)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.tail.data)
@@ -148,7 +163,7 @@ func (s *ListTestSuite) TestInsertAfterShouldAddNodeAtTailIfIndexEqualsLength() 
 }
 
 func (s *ListTestSuite) TestInsertAfterShouldAddNodeAfterIndexedNode() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 
 	index := 0
 	s.listWithTwoItems.InsertAfter(index, nodeValue)
@@ -157,9 +172,9 @@ func (s *ListTestSuite) TestInsertAfterShouldAddNodeAfterIndexedNode() {
 	index = 2
 	s.listWithManyItems.InsertAfter(index, nodeValue)
 
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.head.next.next.next.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.tail.data)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.head.next.next.next.data)
@@ -169,13 +184,13 @@ func (s *ListTestSuite) TestInsertAfterShouldAddNodeAfterIndexedNode() {
 
 func (s *ListTestSuite) TestPopShouldReturnErrorIfListIsEmpty() {
 	result, err := s.emptyList.Pop()
-	s.Assert().Equal("", result)
+	s.Assert().Nil(result)
 	s.Assert().EqualError(err, "[error: empty list]")
 }
 
 func (s *ListTestSuite) TestPopShouldReturnHeadIfListHasOneNode() {
 	result, err := s.listWithOneItem.Pop()
-	s.Assert().Equal("single", result)
+	s.Assert().Equal(&testData{"single"}, result)
 	s.Assert().Nil(err)
 	s.Assert().Equal(0, s.listWithOneItem.length)
 	s.Assert().Equal(s.emptyList, s.listWithOneItem)
@@ -183,17 +198,17 @@ func (s *ListTestSuite) TestPopShouldReturnHeadIfListHasOneNode() {
 
 func (s *ListTestSuite) TestPopShouldReturnHeadIfListHasManyNodes() {
 	result, err := s.listWithManyItems.Pop()
-	s.Assert().Equal("1", result)
+	s.Assert().Equal(&testData{"1"}, result)
 	s.Assert().Nil(err)
 	s.Assert().Equal(3, s.listWithManyItems.length)
-	s.Assert().Equal("2", s.listWithManyItems.head.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.head.next.next.data)
 	s.Assert().Nil(s.listWithManyItems.tail.next)
 }
 
 func (s *ListTestSuite) TesContainsShouldReturnFalseIfListDoesNotContainItem() {
-	testValue := "a"
+	testValue := &testData{"a"}
 	s.Assert().Equal(false, s.emptyList.Contains(testValue))
 	s.Assert().Equal(false, s.listWithOneItem.Contains(testValue))
 	s.Assert().Equal(false, s.listWithTwoItems.Contains(testValue))
@@ -202,14 +217,14 @@ func (s *ListTestSuite) TesContainsShouldReturnFalseIfListDoesNotContainItem() {
 }
 
 func (s *ListTestSuite) TestContainsShouldReturnTrueIfListDoesNotContainItem() {
-	testValue := "single"
+	testValue := &testData{"single"}
 	s.Assert().Equal(true, s.listWithOneItem.Contains(testValue))
 	s.Assert().Equal(true, s.listWithTwoItems.Contains(testValue))
 	s.Assert().Equal(true, s.listWithManyItems.Contains(testValue))
 }
 
 func (s *ListTestSuite) TestIndexOfShouldReturnNegativeOneIfListDoesNotContainItem() {
-	testValue := "a"
+	testValue := &testData{"a"}
 	s.Assert().Equal(-1, s.emptyList.IndexOf(testValue))
 	s.Assert().Equal(-1, s.listWithOneItem.IndexOf(testValue))
 	s.Assert().Equal(-1, s.listWithTwoItems.IndexOf(testValue))
@@ -217,14 +232,14 @@ func (s *ListTestSuite) TestIndexOfShouldReturnNegativeOneIfListDoesNotContainIt
 }
 
 func (s *ListTestSuite) TestIndexOfShouldReturnIndexIfListContainsItem() {
-	testValue := "single"
+	testValue := &testData{"single"}
 	s.Assert().Equal(0, s.listWithOneItem.IndexOf(testValue))
 	s.Assert().Equal(1, s.listWithTwoItems.IndexOf(testValue))
 	s.Assert().Equal(3, s.listWithManyItems.IndexOf(testValue))
 }
 
 func (s *ListTestSuite) TestPushShouldAddNodeToHead() {
-	nodeValue := "new"
+	nodeValue := &testData{"new"}
 
 	s.emptyList.Push(nodeValue)
 	s.Assert().Equal(nodeValue, s.emptyList.head.data)
@@ -245,24 +260,24 @@ func (s *ListTestSuite) TestPushShouldAddNodeToHead() {
 
 	s.listWithManyItems.Push(nodeValue)
 	s.Assert().Equal(nodeValue, s.listWithManyItems.head.data)
-	s.Assert().Equal("1", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.next.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.next.data)
 	s.Assert().Equal(s.singleNodeValue, s.listWithManyItems.head.next.next.next.next.data)
 	s.Assert().Nil(s.listWithManyItems.tail.next)
 	s.Assert().Equal(5, s.listWithManyItems.length)
 }
 
 func (s *ListTestSuite) TestRemoveShouldReturnErrorIfListDoesNotContainItem() {
-	nodeValue := "0"
-	s.Assert().EqualError(s.emptyList.Remove(nodeValue), "[error: \"0\" not found]")
-	s.Assert().EqualError(s.listWithOneItem.Remove(nodeValue), "[error: \"0\" not found]")
-	s.Assert().EqualError(s.listWithTwoItems.Remove(nodeValue), "[error: \"0\" not found]")
-	s.Assert().EqualError(s.listWithManyItems.Remove(nodeValue), "[error: \"0\" not found]")
+	nodeValue := &testData{"0"}
+	s.Assert().EqualError(s.emptyList.Remove(nodeValue), "[error: \"&{0}\" not found]")
+	s.Assert().EqualError(s.listWithOneItem.Remove(nodeValue), "[error: \"&{0}\" not found]")
+	s.Assert().EqualError(s.listWithTwoItems.Remove(nodeValue), "[error: \"&{0}\" not found]")
+	s.Assert().EqualError(s.listWithManyItems.Remove(nodeValue), "[error: \"&{0}\" not found]")
 }
 
 func (s *ListTestSuite) TestRemoveShouldRemoveItemIfListContainsItem() {
-	nodeValue := "single"
+	nodeValue := &testData{"single"}
 	err := s.listWithOneItem.Remove(nodeValue)
 	s.Assert().Equal(s.emptyList, s.listWithOneItem)
 	s.Assert().Nil(err)
@@ -270,17 +285,17 @@ func (s *ListTestSuite) TestRemoveShouldRemoveItemIfListContainsItem() {
 
 	err = s.listWithTwoItems.Remove(nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("1", s.listWithTwoItems.head.data)
-	s.Assert().Equal("1", s.listWithTwoItems.tail.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithTwoItems.head.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithTwoItems.tail.data)
 	s.Assert().Nil(s.listWithTwoItems.head.next)
 	s.Assert().Nil(s.listWithTwoItems.tail.next)
 
 	err = s.listWithManyItems.Remove(nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.tail.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.tail.data)
 	s.Assert().Equal(3, s.listWithManyItems.length)
 	s.Assert().Nil(s.listWithManyItems.tail.next)
 }
@@ -308,37 +323,37 @@ func (s *ListTestSuite) TestRemoveByIndexShouldRemoveIndexedItem() {
 
 	err = s.listWithTwoItems.RemoveByIndex(index)
 	s.Assert().Nil(err)
-	s.Assert().Equal("single", s.listWithTwoItems.head.data)
-	s.Assert().Equal("single", s.listWithTwoItems.tail.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithTwoItems.head.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithTwoItems.tail.data)
 	s.Assert().Nil(s.listWithTwoItems.head.next)
 	s.Assert().Nil(s.listWithTwoItems.tail.next)
 
 	index = 3
 	err = s.listWithManyItems.RemoveByIndex(index)
 	s.Assert().Nil(err)
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.head.next.next.data)
-	s.Assert().Equal("3", s.listWithManyItems.tail.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"3"}, s.listWithManyItems.tail.data)
 	s.Assert().Equal(3, s.listWithManyItems.length)
 	s.Assert().Nil(s.listWithManyItems.tail.next)
 }
 
 func (s *ListTestSuite) TestSetShouldReturnErrorIfIndexExceededLength() {
 	index := 5
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 	s.Assert().EqualError(s.listWithTwoItems.Set(index, nodeValue), "[invalid index: exceeded maximum index (1)]")
 }
 func (s *ListTestSuite) TestSetShouldReturnErrorIfIndexIsNegative() {
 	index := -10
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 
 	s.Assert().EqualError(s.listWithTwoItems.Set(index, nodeValue), "[invalid index: should be [0 - 1]]")
 }
 
 func (s *ListTestSuite) TestSetShouldReturnErrorIfListIsEmpty() {
 	index := 0
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 
 	s.Assert().EqualError(s.emptyList.Set(index, nodeValue), "[error: empty list]")
 }
@@ -346,11 +361,11 @@ func (s *ListTestSuite) TestSetShouldReturnErrorIfListIsEmpty() {
 func (s *ListTestSuite) TestSetShouldSetItemAsHeadAndTailIfListHasOneNode() {
 
 	index := 0
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 	err := s.listWithOneItem.Set(index, nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("0", s.listWithOneItem.head.data)
-	s.Assert().Equal("0", s.listWithOneItem.tail.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithOneItem.head.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithOneItem.tail.data)
 	s.Assert().Nil(s.listWithOneItem.head.next)
 	s.Assert().Nil(s.listWithOneItem.tail.next)
 	s.Assert().Equal(1, s.listWithOneItem.length)
@@ -358,38 +373,38 @@ func (s *ListTestSuite) TestSetShouldSetItemAsHeadAndTailIfListHasOneNode() {
 
 func (s *ListTestSuite) TestSetShouldSetItemAsHeadOrTailIfListHasTwoNodes() {
 
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 
 	index := 0
 	err := s.listWithTwoItems.Set(index, nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("0", s.listWithTwoItems.head.data)
-	s.Assert().Equal("single", s.listWithTwoItems.head.next.data)
-	s.Assert().Equal("single", s.listWithTwoItems.tail.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithTwoItems.head.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithTwoItems.head.next.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithTwoItems.tail.data)
 	s.Assert().Nil(s.listWithTwoItems.tail.next)
 	s.Assert().Equal(2, s.listWithTwoItems.length)
 
 	index = 1
 	err = s.listWithTwoItems.Set(index, nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("0", s.listWithTwoItems.head.data)
-	s.Assert().Equal("0", s.listWithTwoItems.head.next.data)
-	s.Assert().Equal("0", s.listWithTwoItems.tail.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithTwoItems.head.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithTwoItems.head.next.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithTwoItems.tail.data)
 	s.Assert().Nil(s.listWithTwoItems.tail.next)
 	s.Assert().Equal(2, s.listWithTwoItems.length)
 }
 
 func (s *ListTestSuite) TestSetShouldSetItemAsIndexedIfListHasManyNodes() {
 
-	nodeValue := "0"
+	nodeValue := &testData{"0"}
 	index := 2
 	err := s.listWithManyItems.Set(index, nodeValue)
 	s.Assert().Nil(err)
-	s.Assert().Equal("1", s.listWithManyItems.head.data)
-	s.Assert().Equal("2", s.listWithManyItems.head.next.data)
-	s.Assert().Equal("0", s.listWithManyItems.head.next.next.data)
-	s.Assert().Equal("single", s.listWithManyItems.head.next.next.next.data)
-	s.Assert().Equal("single", s.listWithManyItems.tail.data)
+	s.Assert().Equal(&testData{"1"}, s.listWithManyItems.head.data)
+	s.Assert().Equal(&testData{"2"}, s.listWithManyItems.head.next.data)
+	s.Assert().Equal(&testData{"0"}, s.listWithManyItems.head.next.next.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithManyItems.head.next.next.next.data)
+	s.Assert().Equal(&testData{"single"}, s.listWithManyItems.tail.data)
 	s.Assert().Equal(4, s.listWithManyItems.length)
 	s.Assert().Nil(s.listWithManyItems.tail.next)
 }

--- a/main.go
+++ b/main.go
@@ -1,32 +1,47 @@
 package main
 
 import (
-	"Linked-List/list"
 	"fmt"
+
+	"github.com/pguo-480/Linked-List/list"
 )
+
+type testData struct {
+	data string
+}
+
+func (t *testData) Compare(d list.Data) (bool, error) {
+	// Convert input d (a struct implementing list.Data interface) to TestData, "ok" will be false if fields of d not match with fields in TestData
+	compareData, ok := d.(*testData)
+	if !ok {
+		return false, fmt.Errorf("Input cannot be converted to TestData")
+	} else {
+		return t.data == compareData.data, nil
+	}
+}
 
 func main() {
 	list := list.NewLinkedList()
-	list.Add("00")
-	list.Add("aa")
-	list.Add("bb")
-	list.Add("cc")
-	list.InsertAfter(-4, "dd")
+	list.Add(&testData{"00"})
+	list.Add(&testData{"aa"})
+	list.Add(&testData{"bb"})
+	list.Add(&testData{"cc"})
+	list.InsertAfter(-4, &testData{"dd"})
 	list.Print()
-	fmt.Println(list.Contains("cc"))
+	fmt.Println(list.Contains(&testData{"cc"}))
 	list.Pop()
 	list.Print()
-	fmt.Println(list.Contains("00"))
-	fmt.Println(list.IndexOf("cc"))
-	fmt.Println(list.IndexOf("00"))
+	fmt.Println(list.Contains(&testData{"00"}))
+	fmt.Println(list.IndexOf(&testData{"cc"}))
+	fmt.Println(list.IndexOf(&testData{"00"}))
 	list.Print()
-	list.Remove("ee")
-	list.Push("22")
-	list.Push("11")
-	list.Push("00")
+	list.Remove(&testData{"ee"})
+	list.Push(&testData{"22"})
+	list.Push(&testData{"11"})
+	list.Push(&testData{"00"})
 	list.RemoveByIndex(1)
 	list.Print()
-	list.Set(6, "11")
-	list.Set(1, "11")
+	list.Set(6, &testData{"11"})
+	list.Set(1, &testData{"11"})
 	list.Print()
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"Linked-List/list"
 	"fmt"
-	"linkedList/list"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/pguo-480/Linked-List/list"
+	"github.com/lyonusi/Linked-List/list"
 )
 
 type testData struct {


### PR DESCRIPTION
**LinkedList data type change**
Changed data type in LinkedList from string to a comparable data structure, so we can use this LinkedList library in HashMap with a struct like this:
```
type Node struct {
    Key string
    Value interface{}
}
```
and let Node implement `Compare` method in list.Data interface

**Go module path change**

changed go module path to your Github project path, so in Hashmap we can install the LinkedList library with 
```
go get github.com/lyonusi/Linked-List
```

We may need to add the latest commit id  to `go get` command if it can't pull the latest commit from Github

```
github.com/pguo-480/Linked-List@commit-id
```

After use `go get` to install LinkedList, we can use the library like this

![image](https://user-images.githubusercontent.com/16546502/132108994-cd1b8f15-a805-4871-a25c-f29a10900ad0.png)

